### PR TITLE
Fix warning for missing include of time.h and more warnings and missing optimisation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@
 #
 
 CC=gcc
+CFLAGS=-Wall -W -g -O2
 
 ARCH:= $(shell uname -p)
 ifneq ($(ARCH),ppc64le)
@@ -31,16 +32,16 @@ install_files = $(TARGETS) capi-flash-script.sh psl-devices
 all: $(TARGETS)
 
 capi-flash-AlphaData7v3: src/capi_flash_ad7v3ku3_user.c
-	$(CC) $< -o $@
+	$(CC) $(CFLAGS) $< -o $@
 
 capi-flash-AlphaDataKU60: src/capi_flash_ad7v3ku3_user.c
-	$(CC) $< -o $@
+	$(CC) $(CFLAGS) $< -o $@
 
 capi-flash-AlphaDataKU115: src/capi_flash_adku115_user.c
-	$(CC) $< -o $@
+	$(CC) $(CFLAGS) $< -o $@
 
 capi-flash-Nallatech: src/capi_flash_nallatech_user.c
-	$(CC) $< -o $@
+	$(CC) $(CFLAGS) $< -o $@
 
 install: $(TARGETS)
 	@chmod a+x capi-flash-*

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ install: $(TARGETS)
 	@chmod a+x capi-flash-*
 	@mkdir -p $(prefix)/capi-utils
 	@cp $(install_files) $(prefix)/capi-utils
-	@ln -s $(prefix)/capi-utils/capi-flash-script.sh \
+	@ln -sf $(prefix)/capi-utils/capi-flash-script.sh \
 		$(prefix)/bin/capi-flash-script
 
 .PHONY: uninstall

--- a/src/capi_flash_ad7v3ku3_user.c
+++ b/src/capi_flash_ad7v3ku3_user.c
@@ -29,6 +29,7 @@
 #include <ctype.h>
 #include <termios.h>
 #include <endian.h>
+#include <time.h>
 
 int main (int argc, char *argv[])
 {

--- a/src/capi_flash_adku115_user.c
+++ b/src/capi_flash_adku115_user.c
@@ -29,6 +29,7 @@
 #include <ctype.h>
 #include <termios.h>
 #include <endian.h>
+#include <time.h>
 
 int main (int argc, char *argv[])
 {

--- a/src/capi_flash_bwvu095_user.c
+++ b/src/capi_flash_bwvu095_user.c
@@ -29,6 +29,7 @@
 #include <ctype.h>
 #include <termios.h>
 #include <endian.h>
+#include <time.h>
 
 int main (int argc, char *argv[])
 {

--- a/src/capi_flash_nallatech_user.c
+++ b/src/capi_flash_nallatech_user.c
@@ -29,6 +29,7 @@
 #include <ctype.h>
 #include <termios.h>
 #include <endian.h>
+#include <time.h>
 
 int main (int argc, char *argv[])
 {


### PR DESCRIPTION
On my Ubuntu system I got warnings about missing include of time.h. I fixed that.
Doing that I figured that the code was build without any warnings and without optimisation
flags, which I think is usually not a good idea on System p. I enabled both.

For the optimisation piece: We might need check if the application is timing-wise ok. If enabling optimisation broke it, it might have had a problem anyways. So have a look and at best try, before merging the last patch.

Signed-off-by: Frank Haverkamp <haver@linux.vnet.ibm.com>