### PR TITLE
Adding features to allow automatic execution of the script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ capi-flash-AlphaDataKU115: src/capi_flash_adku115_user.c
 capi-flash-Nallatech: src/capi_flash_nallatech_user.c
 	$(CC) $(CFLAGS) $< -o $@
 
+.PHONY: install
 install: $(TARGETS)
 	@chmod a+x capi-flash-*
 	@mkdir -p $(prefix)/capi-utils
@@ -53,7 +54,7 @@ install: $(TARGETS)
 .PHONY: uninstall
 uninstall:
 	@rm -rf $(prefix)/capi-utils
-	@rm $(prefix)/bin/capi-flash-script
+	@rm -f $(prefix)/bin/capi-flash-script
 
 .PHONY: clean
 clean:

--- a/capi-flash-script.sh
+++ b/capi-flash-script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2016 International Business Machines
+# Copyright 2016, 2017 International Business Machines
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,60 @@
 #
 # Usage: sudo capi-flash-script.sh <path-to-bit-file>
 
+version=1.0
+force=0
+program=`basename "$0"`
+card=-1
+
+# Print usage message helper function
+function usage() {
+  echo "Usage:  sudo ${program} [OPTIONS]"
+  echo "    [-C <card>] card to flash."
+  echo "    [-f] force execution without asking."
+  echo "         warning: use with care e.g. for automation."
+  echo "    [-V] Print program version (${version})"
+  echo "    [-h] Print this help message."
+  echo "    <path-to-bit-file>"
+  echo
+  echo "Utility to flash/write bitstreams to CAPI FPGA cards."
+  echo "Please ensure that you are using the right bitstream data."
+  echo "Using non-functional bitstream data or aborting the process"
+  echo "can leave your card in a state where a hardware debugger is"
+  echo "required to make the card usable again."
+  echo
+}
+
+# Parse any options given on the command line
+while getopts ":C:fVh" opt; do
+  case ${opt} in
+      C)
+      card=$OPTARG
+      ;;
+      f)
+      force=1
+      ;;
+      V)
+      echo "${version}" >&2
+      exit 0
+      ;;
+      h)
+      usage;
+      exit 0
+      ;;
+      \?)
+      printf "${bold}ERROR:${normal} Invalid option: -${OPTARG}\n" >&2
+      exit 1
+      ;;
+      :)
+      printf "${bold}ERROR:${normal} Option -$OPTARG requires an argument.\n" >&2
+      exit 1
+      ;;
+  esac
+done
+
+shift $((OPTIND-1))
+# now do something with $@
+
 ulimit -c unlimited
 
 # stop on non-zero response
@@ -27,7 +81,7 @@ normal=$(tput sgr0)
 
 # make sure script runs as root
 if [[ $EUID -ne 0 ]]; then
-  printf "${bold}ERROR:${normal} This script must run as root\n"
+  printf "${bold}ERROR:${normal} This script must run as root (${EUID})\n"
   exit 1
 fi
 
@@ -103,20 +157,30 @@ done < <(lspci -d "1014":"477" )
 
 printf "\n"
 
-# prompt card to flash to
-while true; do
-  read -p "Which card do you want to flash? [0-$(($n - 1))] " c
-  if ! [[ $c =~ ^[0-9]+$ ]]; then
-    printf "${bold}ERROR:${normal} Invalid input\n"
-  else
-    c=$((10#$c))
-    if (( "$c" >= "$n" )); then
-      printf "${bold}ERROR:${normal} Wrong card number\n"
-    else
-      break
-    fi
+# card is set via parameter since it is positive
+if (($card >= 0)); then
+  c=$((10#$card))
+  if (( "$c" >= "$n" )); then
+    printf "${bold}ERROR:${normal} Wrong card number ${card}\n"
+    exit 1
   fi
-done
+else
+# prompt card to flash to
+  while true; do
+    read -p "Which card do you want to flash? [0-$(($n - 1))] " c
+    if ! [[ $c =~ ^[0-9]+$ ]]; then
+      printf "${bold}ERROR:${normal} Invalid input\n"
+    else
+      c=$((10#$c))
+      if (( "$c" >= "$n" )); then
+        printf "${bold}ERROR:${normal} Wrong card number\n"
+        exit 1
+      else
+        break
+      fi
+    fi
+  done
+fi
 
 printf "\n"
 
@@ -134,20 +198,31 @@ else
   fi
 fi
 
-# prompt to confirm
-while true; do
-  read -p "Do you want to continue to flash ${bold}$1${normal} to ${bold}card$c${normal}? [y/n] " yn
-  case $yn in
-    [Yy]* ) break;;
-    [Nn]* ) exit;;
-    * ) printf "${bold}ERROR:${normal} Please answer with y or n\n";;
-  esac
-done
+# card is set via parameter since it is positive
+if (($force != 1)); then
+  # prompt to confirm
+  while true; do
+    read -p "Do you want to continue to flash ${bold}$1${normal} to ${bold}card$c${normal}? [y/n] " yn
+    case $yn in
+      [Yy]* ) break;;
+      [Nn]* ) exit;;
+      * ) printf "${bold}ERROR:${normal} Please answer with y or n\n";;
+    esac
+  done
+else
+  printf "Continue to flash ${bold}$1${normal} to ${bold}card$c${normal}\n"
+fi
 
 printf "\n"
 
 # update flash history file
 printf "%-29s %-20s %s\n" "$(date)" "$(logname)" $1 > /var/cxl/card$c
+
+# Check if lowlevel flash utility is existing and executable
+if [ ! -x $pwd/../capi-utils/capi-flash-${board_vendor[$c]} ]; then
+  printf "${bold}ERROR:${normal} Utility capi-flash-${board_vendor[$c]} not found!\n"
+  exit 1
+fi
 
 # flash card with corresponding binary
 $pwd/../capi-utils/capi-flash-${board_vendor[$c]} $1 $c || printf "${bold}ERROR:${normal} Something went wrong\n"


### PR DESCRIPTION
Hi Kenneth,

we like to use the script in out automated regression test environment. For this purpose we cannot type y/n and the card number manually. We hopefully know what we do there, so I added code
to avoid those manual steps. With -f we can force now the automatic installation and we can provide with -C <card> the desired card. I wondered if we could lift the sudo requirement too, but setting chmod a+s capi-flash-script.pl did not yield the desired results (ideas welcome).

I saw that the tool writes a lock file in a privileged directory. Is there anything else which absolutely requires superuser rights? What is your view lifting this requirement?

Anyways, here are my suggestions to include in the repository. Please have a look and merge if you think they are fine.

Thanks

Frank