### PR TITLE
Makefile: Add cross compilation support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+ifneq ($(CROSS_COMPILE),)
+CC=$(CROSS_COMPILE)gcc
+endif
 
-CC=gcc
 CFLAGS=-Wall -W -g -O2
 
-ARCH:= $(shell uname -p)
-ifneq ($(ARCH),ppc64le)
-  $(error $(ARCH) does not support CAPI)
+ARCH_SUPPORTED:=$(shell echo -e "\n\#if !(defined(_ARCH_PPC64) && defined(_LITTLE_ENDIAN))"\
+	"\n\#error \"This tool is only supported on ppc64le architecture\""\
+	"\n\#endif" | ($(CC) $(CFLAGS) -E -o /dev/null - 2>&1 || exit 1))
+
+ifneq ($(strip $(ARCH_SUPPORTED)),)
+$(error Target not supported. Currently CAPI utils is only supported on ppc64le)
 endif
 
 prefix=/usr/local


### PR DESCRIPTION
This adds cross compilation support for CAPI utils. We check if the
provide cross-compiler supports target ppc64le by invoking a the
compiler with a small codelet that checks for ppc64le macros. Proceed
with the build only if provided gcc passes the build test.

Test Run (Host:ppc64le Cross:ppc64le)
$ make
cc -Wall -W -g -O2 src/capi_flash_ad7v3ku3_user.c -o capi-flash-AlphaData7v3
....

Test Run (Host:x64 Target:ppc64le)
$ make CROSS_COMPILE=powerpc64le-unknown-linux-gnu-
powerpc64le-unknown-linux-gnu-gcc -Wall -W -g -O2 src/capi_flash_ad7v3ku3_user.c
....

Test Run (Host:x64 Target:x64) - Unsupported
$ make
Makefile:27: *** Target not supported. Currently CAPI utils is only
supported on ppc64le. Stop.

Signed-off-by: Vaibhav Jain <vaibhav@linux.vnet.ibm.com>