### PR TITLE
Fix bug #35

### DIFF
--- a/capi-flash-script.sh
+++ b/capi-flash-script.sh
@@ -192,11 +192,14 @@ if [[ ${fpga_type[$c]} == "Altera" ]]; then
     printf "${bold}ERROR: ${normal}Wrong file extension: .rbf must be used for boards with Altera FPGA\n"
     exit 0
   fi
-else
+elif [[ ${fpga_type[$c]} == "Xilinx" ]]; then
   if [[ $FILE_EXT != "bin" ]]; then
     printf "${bold}ERROR: ${normal}Wrong file extension: .bin must be used for boards with Xilinx FPGA\n"
     exit 0
   fi
+else 
+  printf "${bold}ERROR: ${normal}Card not listed in psl-devices!\n"
+  exit 0
 fi
 
 # get flash address and block size

--- a/psl-devices
+++ b/psl-devices
@@ -13,3 +13,4 @@
 0x0609 BittwareVU095 Xilinx
 0x060a NallatechKU60 Xilinx       0x2000000 256
 0x04dd NallatechN250SP Xilinx     0x4000000 256
+0x060d NallatechN250SP Xilinx     0x4000000 256

--- a/src/capi_flash.c
+++ b/src/capi_flash.c
@@ -303,9 +303,14 @@ int main (int argc, char *argv[])
 			{ "factory",   required_argument, NULL, 'p' },
 			{ 0,           no_argument,       NULL, 0   },
 		};
-		cmd = getopt_long(argc, argv, "vhVqpC:a:b:f:",
+		cmd = getopt_long(argc, argv, ":vhVqpC:a:b:f:",
 				long_options, &option_index);
 		if (-1 == cmd) break;   /* all params processed ? */ 
+		/* if next option is taken as argument when the required argument is missing */
+		if (optarg && (optarg[0] == '-') ) {
+		        eprintf("%s Invalid or missing argument for option '-%c': %s\n", argv[0], cmd, optarg);
+			exit(0);
+		}
 		switch (cmd) {
 		case 'v':
 			verbose++;
@@ -336,8 +341,13 @@ int main (int argc, char *argv[])
 		case 'p':  /* factory */
 			factory = true;
 			break;
+		case ':': /* missing argument (: must be first in getopt_long) */
+		        eprintf("%s Missing argument for option '-%c'\n", argv[0], optopt);
+			help(argv[0]);
+			exit(0);
+		case '?':
 		default:
-			eprintf("%s Invalid Option\n", argv[0]);
+			eprintf("%s Invalid Option '-%c'\n", argv[0], optopt);
 			help(argv[0]);
 			exit(0);
 		}


### PR DESCRIPTION
Fix in capi_flash.c: insist on required command arguments, don't let the next command be treated as argument for the previous one.

Fix in psl-devices: Add CAPI SNAP/HDK version of N250SP card

Fix in capi-flash-script.sh: Stop if a card is not listed in psl-devices

Signed-off-by: Joerg-Stephan Vogt <jsvogt@de.ibm.com>