### PR TITLE
add U200 device

### DIFF
--- a/psl-devices
+++ b/psl-devices
@@ -18,3 +18,4 @@
 0x060f AlphadataVU3P Xilinx       0x1000000 64  SPIx8 0x3000000
 0x0660 SemptianNSA241 Xilinx      0x8000000 64  SPIx4
 0x0661 FlysliceVU9P Xilinx        0x4000000 64  SPIx4
+0x0665 U200 Xilinx                0x1002000 64  SPIx4


### PR DESCRIPTION
Add subsystem ID in psl-devices to recognize the card.

Signed-off-by: Lu Yong <luyong@cn.ibm.com>